### PR TITLE
Take `token` in input to use in GitHub CLI for posting PR comment

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,10 @@ inputs:
     description: 'Commit SHA used to search for pull request number.'
     required: false
     default: ${{ github.sha }}
+  token:
+    description: 'GitHub token used to post comment.'
+    required: false
+    default: ${{ github.token }}
   fail:
     description: 'Fail this action.'
     required: false
@@ -41,9 +45,9 @@ runs:
         TAG: '<comment-pull-request:${{ inputs.grouping-key }}>'
         PREVIOUS_COMMENT: ${{ inputs.previous-comment }}
         PR_NUMBER: ${{ inputs.pull-request-number }}
-        SHA: ${{ inputs.sha }}        
+        SHA: ${{ inputs.sha }}
         GH_REPO: ${{ github.repository }} # for GitHub CLI
-        GH_TOKEN: ${{ github.token }} # for GitHub CLI
+        GH_TOKEN: ${{ inputs.token }} # for GitHub CLI
         IS_VALID_PREVIOUS_COMMENT: ${{ inputs.previous-comment != null && contains(fromJSON('["delete","hide","edit","keep"]'), inputs.previous-comment) }}
       run: |
         echo "::debug::gh version: $(gh --version | tr '\n' ' ')"


### PR DESCRIPTION
Close #13 

* Add `token` to input list.
  * Mark not-required, use default token if not specified. Same manner as [`actions/checkout`](https://github.com/actions/checkout/blob/main/action.yml)
  * Mainly used with token provided from GitHub App.
* Use the given token in GitHub CLI, which posts the comment to PR.

I'll test the new input in my repo with my PAT.